### PR TITLE
Ignore all, then unignore files on .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,24 +1,30 @@
+# Ignore everything
+**
+
+# Un-ignore relevant files
+
 # yarn
-.yarn/*
-!.yarn/cache
-!.yarn/releases
-!.yarn/plugins
+!/.yarn/cache/**
+!/.yarn/releases/**
+!/.yarn/plugins/**
+!/.pnp.js
+!/.yarnrc.yml
+!/yarn.lock
+!/package.json
+
+# typescript
+!/tsconfig.json
+
+# source code
+!/packages/**
+!/services/**
+
+# Ignore unnecessary files that may be inside allowed directories
+# This should go after the allowed directories
 
 # git
-.git
-.gitattributes
-.gitignore
+**/.gitattributes
+**/.gitignore
 
-# Visual Studio Code
-.vscode
-
-# Docker
-Dockerfile
-docker-compose.yml
-/docker
-
-# Kubernetes
-/kubernetes
-
-# Deploy
-/deploy_local.sh
+# macOS
+**/.DS_Store


### PR DESCRIPTION
Since we add all files to the docker image, its better to only pick the files relevant to run the application. So, instead of ignoring stuff on the .dockerignore, lets explicit add them.

This fixes the problem of adding a new file not relevant to the runtime, forgetting to put it as ignored and thus invalidating the image.