### PR TITLE
Fix sed in deploy_local.sh

### DIFF
--- a/deploy_local.sh
+++ b/deploy_local.sh
@@ -25,7 +25,7 @@ tmp_dir=$(mktemp -d -t poluga_deploy_XXXXXXX)
 cp -a kubernetes/. ${tmp_dir}/
 
 # Replace placeholder with image tag
-sed -i '' "s/\$IMAGE_TAG/$tag/g" $tmp_dir/kustomization.yaml
+sed -i "s/\$IMAGE_TAG/$tag/g" $tmp_dir/kustomization.yaml
 
 # Apply manifests to cluster
 kubectl apply -k $tmp_dir


### PR DESCRIPTION
sed command on macOS is different from Linux's sed. But by using Linux sed we can make it work inside a container (image will be Linux). For the moment mac users will need to patch the script to be able to deploy locally :frowning_face: 